### PR TITLE
fix: remove undefined age reference in promise challenge

### DIFF
--- a/1-js-and-async-programming/2-asynchronous-js/2-promise.js
+++ b/1-js-and-async-programming/2-asynchronous-js/2-promise.js
@@ -33,6 +33,6 @@ const getUsersWithMoreDislikedMoviesThanLikedMovies = () => {
 getUsersWithMoreDislikedMoviesThanLikedMovies().then((users) => {
   console.log("Users with more disliked movies than liked movies:");
   users.forEach((user) => {
-    console.log(user, age);
+    console.log(user);
   });
 });


### PR DESCRIPTION
## The bug

`1-js-and-async-programming/2-promise.js` logged `age`, which is not defined anywhere in the file:

```js
users.forEach((user) => {
  console.log(user, age); // ReferenceError: age is not defined
});
```

## Why it's worth fixing

The timing is the nasty part. The stub returns an empty array, so `forEach` never iterates and the file appears fine. The crash only surfaces **once a Nerd has implemented the challenge correctly** and there are finally users to print — so the exercise blows up at the exact moment their work starts paying off, in provided harness code they didn't write and aren't expected to touch.

That's a bad first lesson in debugging: the stack trace points at a line the Nerd has no reason to suspect.

## The fix

```diff
-    console.log(user, age);
+    console.log(user);
```

`user` is already the whole object, so this prints `{ id, name, age }` — the age included, and consistent with the challenge's "only print the user information" requirement.

## Verified

Reproduced against `main` and confirmed on this branch, using a throwaway harness that makes the stub resolve to one user (the exercise itself is left unsolved):

```
=== BEFORE (main) ===
Users with more disliked movies than liked movies:
    console.log(user, age);
                      ^
ReferenceError: age is not defined

=== AFTER (this branch) ===
Users with more disliked movies than liked movies:
{ id: 3, name: 'Alice Johnson', age: 28 }
```

`eslint` exits 0 on the file and `prettier --check` passes. One-line diff; nothing else touched.

---

Found while working on #17. Independent of that PR — different file, no conflict, either can merge first.
